### PR TITLE
Fix optional 'content' parameter being marked required in MCP schema

### DIFF
--- a/csharp-lsp-mcp/src/CSharpLspMcp/Tools/CSharpTools.cs
+++ b/csharp-lsp-mcp/src/CSharpLspMcp/Tools/CSharpTools.cs
@@ -108,8 +108,8 @@ public class CSharpTools
     [Description("Get compiler errors and warnings for C# code. Opens the document in the LSP if not already open.")]
     public Task<string> GetDiagnosticsAsync(
         [Description("Absolute path to the C# file")] string filePath,
-        [Description("Content of the file (optional, reads from disk if not provided)")] string? content,
-        CancellationToken cancellationToken)
+        [Description("Content of the file (optional, reads from disk if not provided)")] string? content = null,
+        CancellationToken cancellationToken = default)
     {
         return ExecuteToolAsync("csharp_diagnostics", async ct =>
         {
@@ -152,8 +152,8 @@ public class CSharpTools
         [Description("Absolute path to the C# file")] string filePath,
         [Description("0-based line number")] int line,
         [Description("0-based character position")] int character,
-        [Description("Content of the file (optional)")] string? content,
-        CancellationToken cancellationToken)
+        [Description("Content of the file (optional)")] string? content = null,
+        CancellationToken cancellationToken = default)
     {
         return ExecuteToolAsync("csharp_hover", async ct =>
         {
@@ -174,7 +174,7 @@ public class CSharpTools
         [Description("Absolute path to the C# file")] string filePath,
         [Description("0-based line number")] int line,
         [Description("0-based character position")] int character,
-        [Description("Content of the file (optional)")] string? content,
+        [Description("Content of the file (optional)")] string? content = null,
         [Description("Maximum number of completions to return (default: 20)")] int maxResults = 20,
         CancellationToken cancellationToken = default)
     {
@@ -211,8 +211,8 @@ public class CSharpTools
         [Description("Absolute path to the C# file")] string filePath,
         [Description("0-based line number")] int line,
         [Description("0-based character position")] int character,
-        [Description("Content of the file (optional)")] string? content,
-        CancellationToken cancellationToken)
+        [Description("Content of the file (optional)")] string? content = null,
+        CancellationToken cancellationToken = default)
     {
         return ExecuteToolAsync("csharp_definition", async ct =>
         {
@@ -243,7 +243,7 @@ public class CSharpTools
         [Description("Absolute path to the C# file")] string filePath,
         [Description("0-based line number")] int line,
         [Description("0-based character position")] int character,
-        [Description("Content of the file (optional)")] string? content,
+        [Description("Content of the file (optional)")] string? content = null,
         [Description("Include the declaration in results (default: true)")] bool includeDeclaration = true,
         CancellationToken cancellationToken = default)
     {
@@ -277,8 +277,8 @@ public class CSharpTools
     [Description("Get all symbols (classes, methods, properties, etc.) in a document")]
     public Task<string> GetSymbolsAsync(
         [Description("Absolute path to the C# file")] string filePath,
-        [Description("Content of the file (optional)")] string? content,
-        CancellationToken cancellationToken)
+        [Description("Content of the file (optional)")] string? content = null,
+        CancellationToken cancellationToken = default)
     {
         return ExecuteToolAsync("csharp_symbols", async ct =>
         {
@@ -320,8 +320,8 @@ public class CSharpTools
         [Description("0-based start character")] int startCharacter,
         [Description("0-based end line")] int endLine,
         [Description("0-based end character")] int endCharacter,
-        [Description("Content of the file (optional)")] string? content,
-        CancellationToken cancellationToken)
+        [Description("Content of the file (optional)")] string? content = null,
+        CancellationToken cancellationToken = default)
     {
         return ExecuteToolAsync("csharp_code_actions", async ct =>
         {
@@ -364,8 +364,8 @@ public class CSharpTools
         [Description("0-based line number")] int line,
         [Description("0-based character position")] int character,
         [Description("The new name for the symbol")] string newName,
-        [Description("Content of the file (optional)")] string? content,
-        CancellationToken cancellationToken)
+        [Description("Content of the file (optional)")] string? content = null,
+        CancellationToken cancellationToken = default)
     {
         return ExecuteToolAsync("csharp_rename", async ct =>
         {


### PR DESCRIPTION
## Summary

Fixes #5.

The `content` parameter on `csharp_diagnostics`, `csharp_hover`, `csharp_completions`, `csharp_definition`, `csharp_references`, `csharp_symbols`, `csharp_code_actions` and `csharp_rename` is documented as *optional*, and `EnsureDocumentOpenAsync` already falls back to `File.ReadAllTextAsync` when it is `null`:

```csharp
content ??= await File.ReadAllTextAsync(filePath, ct);
```

However, the parameters were declared as `string? content` **without a default value**, and the MCP SDK (`AIFunctionFactory`) marks parameters without defaults as `required` in the generated JSON schema — nullability alone is not enough. MCP clients (e.g. Claude Code) were therefore forced to send the full file content on every call, which is wasteful for large files.

## Change

- Added `= null` defaults to all `string? content` tool parameters
- Added `= default` to the trailing `CancellationToken` parameters where required by C# optional-parameter ordering rules

No behavioral change for callers that pass `content`; callers that omit it now get the documented read-from-disk behavior instead of a schema validation error.

## Verification

`tools/list` schema after the change — `content` no longer in `required` for any tool:

```
csharp_set_workspace      required=['path']
csharp_definition         required=['filePath', 'line', 'character']
csharp_completions        required=['filePath', 'line', 'character']
csharp_code_actions       required=['filePath', 'startLine', 'startCharacter', 'endLine', 'endCharacter']
csharp_references         required=['filePath', 'line', 'character']
csharp_diagnostics        required=['filePath']
csharp_rename             required=['filePath', 'line', 'character', 'newName']
csharp_hover              required=['filePath', 'line', 'character']
csharp_symbols            required=['filePath']
```

Functional test on a real multi-project solution (macOS arm64): `csharp_set_workspace` + `csharp_symbols` **without** `content` correctly reads the file from disk and returns document symbols.

🤖 Generated with [Claude Code](https://claude.com/claude-code)