### PR TITLE
feat: same-line position tolerance for position-based C# tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Same-line position-tolerance ring for the position-based C# tools (`csharp_definition`,
+  `csharp_hover`, `csharp_references`, `csharp_completions`). On a miss the server retries a small
+  ring of nearby character offsets (`exact, -1, +1, -2`) **on the same line only** (hard-clamped to
+  the line, never crossing onto an adjacent line), which self-heals off-by-one positions supplied by
+  AI / MCP callers that lack a real editor caret. Exact hits issue exactly one probe (no behavior or
+  performance change on the happy path); a recovered lookup is logged via `ILogger`; a true miss
+  returns a recovery-oriented, 0-based message.
+- Opt-in, lock-safe JSONL telemetry sink for tolerance outcomes, activated by the
+  `CSHARP_LSP_TOLERANCE_LOG` environment variable (a no-op when unset). Appends one JSON object per
+  line — `{ ts, tool, line, requested, winning, delta, outcome }` — so the winning-offset histogram
+  (`exact` / `tolerance` / `miss`, grouped by `delta`) can be analyzed to validate the ring.
+
 ## [1.0.0] - 2025-12-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -178,8 +178,24 @@ OPTIONS:
     -V, --verbose   Enable verbose logging (to stderr)
 
 ENVIRONMENT VARIABLES:
-    MCP_DEBUG=1     Enable trace-level logging
+    MCP_DEBUG=1                  Enable trace-level logging
+    CSHARP_LSP_TOLERANCE_LOG    Path to a JSONL file for position-tolerance telemetry (opt-in)
 ```
+
+### Position tolerance (for AI / MCP callers)
+
+The position-based tools — `csharp_hover`, `csharp_completions`, `csharp_definition`, and
+`csharp_references` — apply a **same-line position-tolerance ring** on the miss path. AI callers
+compute `(line, character)` from text rather than a real editor caret and frequently land a
+character or two off the target symbol. Instead of failing immediately, the server retries a small
+ring of nearby character offsets (`exact, -1, +1, -2`) **on the same line only** — hard-clamped to
+the line so a retry can never resolve a symbol on an adjacent line. An exact hit issues exactly one
+probe, so there is no behavior or performance change when the position is already correct.
+
+Set `CSHARP_LSP_TOLERANCE_LOG` to a file path to record each outcome as a line of JSON
+(`{ ts, tool, line, requested, winning, delta, outcome }`, where `outcome` is `exact`, `tolerance`,
+or `miss`). Grouping the records by `delta` yields a winning-offset histogram for tuning the ring.
+The sink is a no-op when the variable is unset.
 
 ## Architecture
 

--- a/csharp-lsp-mcp/src/CSharpLspMcp.Tests/ToleranceTelemetrySinkTests.cs
+++ b/csharp-lsp-mcp/src/CSharpLspMcp.Tests/ToleranceTelemetrySinkTests.cs
@@ -1,0 +1,127 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using CSharpLspMcp.Tools;
+using Xunit;
+
+namespace CSharpLspMcp.Tests;
+
+/// <summary>
+/// Covers the opt-in JSONL winning-offset telemetry sink (kb-4110 / AI-536): disabled by default,
+/// correct outcome/delta classification, and lock-safe concurrent appends with no torn lines.
+/// </summary>
+public class ToleranceTelemetrySinkTests
+{
+    [Fact]
+    public void Sink_WithNoPath_IsDisabledAndRecordIsNoOp()
+    {
+        var sink = new ToleranceTelemetrySink(null);
+
+        Assert.False(sink.IsEnabled);
+        sink.Record("csharp_hover", line: 1, requested: 2, winning: 2); // must not throw
+    }
+
+    [Fact]
+    public void Sink_WithWhitespacePath_IsDisabled()
+    {
+        Assert.False(new ToleranceTelemetrySink("   ").IsEnabled);
+    }
+
+    [Theory]
+    [InlineData(8, 8, "exact", 0)]
+    [InlineData(8, 7, "tolerance", -1)]
+    [InlineData(8, 9, "tolerance", 1)]
+    public void BuildRecord_ClassifiesOutcomeAndDelta(int requested, int winning, string expectedOutcome, int expectedDelta)
+    {
+        var json = ToleranceTelemetrySink.BuildRecord(
+            "csharp_definition", line: 12, requested: requested, winning: winning,
+            timestamp: DateTimeOffset.UnixEpoch);
+
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        Assert.Equal("csharp_definition", root.GetProperty("tool").GetString());
+        Assert.Equal(12, root.GetProperty("line").GetInt32());
+        Assert.Equal(requested, root.GetProperty("requested").GetInt32());
+        Assert.Equal(winning, root.GetProperty("winning").GetInt32());
+        Assert.Equal(expectedDelta, root.GetProperty("delta").GetInt32());
+        Assert.Equal(expectedOutcome, root.GetProperty("outcome").GetString());
+        Assert.Equal("1970-01-01T00:00:00.000Z", root.GetProperty("ts").GetString());
+    }
+
+    [Fact]
+    public void BuildRecord_NullWinning_IsMissWithNullDelta()
+    {
+        var json = ToleranceTelemetrySink.BuildRecord(
+            "csharp_references", line: 3, requested: 5, winning: null,
+            timestamp: DateTimeOffset.UnixEpoch);
+
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        Assert.Equal("miss", root.GetProperty("outcome").GetString());
+        Assert.Equal(JsonValueKind.Null, root.GetProperty("winning").ValueKind);
+        Assert.Equal(JsonValueKind.Null, root.GetProperty("delta").ValueKind);
+    }
+
+    [Fact]
+    public void Record_AppendsOneWellFormedJsonLinePerCall()
+    {
+        var path = NewTempLogPath();
+        try
+        {
+            var sink = new ToleranceTelemetrySink(path);
+            Assert.True(sink.IsEnabled);
+
+            sink.Record("csharp_hover", line: 0, requested: 4, winning: 4);
+            sink.Record("csharp_definition", line: 1, requested: 9, winning: 8);
+
+            var lines = File.ReadAllLines(path);
+            Assert.Equal(2, lines.Length);
+            Assert.All(lines, l => Assert.Equal(JsonValueKind.Object, JsonDocument.Parse(l).RootElement.ValueKind));
+        }
+        finally
+        {
+            TryDelete(path);
+        }
+    }
+
+    [Fact]
+    public async Task Record_IsLockSafeUnderConcurrency_NoTornLines()
+    {
+        var path = NewTempLogPath();
+        try
+        {
+            var sink = new ToleranceTelemetrySink(path);
+            const int writers = 8;
+            const int perWriter = 50;
+
+            var tasks = Enumerable.Range(0, writers).Select(w => Task.Run(() =>
+            {
+                for (var i = 0; i < perWriter; i++)
+                    sink.Record("csharp_completions", line: w, requested: i, winning: i - 1);
+            }));
+            await Task.WhenAll(tasks);
+
+            var lines = File.ReadAllLines(path);
+            Assert.Equal(writers * perWriter, lines.Length);
+            // Every line must be a complete, parseable JSON object (no interleaved/torn writes).
+            Assert.All(lines, l => Assert.Equal("tolerance", JsonDocument.Parse(l).RootElement.GetProperty("outcome").GetString()));
+        }
+        finally
+        {
+            TryDelete(path);
+        }
+    }
+
+    private static string NewTempLogPath()
+        => Path.Combine(Path.GetTempPath(), $"csharp-lsp-tolerance-{Guid.NewGuid():N}.jsonl");
+
+    private static void TryDelete(string path)
+    {
+        try { if (File.Exists(path)) File.Delete(path); }
+        catch (IOException) { /* best-effort cleanup */ }
+    }
+}

--- a/csharp-lsp-mcp/src/CSharpLspMcp.Tests/ToleranceTests.cs
+++ b/csharp-lsp-mcp/src/CSharpLspMcp.Tests/ToleranceTests.cs
@@ -1,0 +1,109 @@
+using System.Threading;
+using System.Threading.Tasks;
+using CSharpLspMcp.Tools;
+using Xunit;
+
+namespace CSharpLspMcp.Tests;
+
+/// <summary>
+/// Covers the same-line position-tolerance ring (kb-4110 / AI-536): exact hit issues no extra
+/// probes, a -1 near-miss resolves, and the ring is hard-clamped to the current line.
+/// </summary>
+public class ToleranceTests
+{
+    [Fact]
+    public async Task TryWithTolerance_ExactHit_IssuesNoExtraProbes()
+    {
+        var calls = 0;
+        var (result, winning) = await CSharpTools.TryWithToleranceAsync<string>(
+            content: "var value = 1;",
+            line: 0,
+            character: 4,
+            probe: (ch, _) =>
+            {
+                calls++;
+                return Task.FromResult<string?>(ch == 4 ? "hit" : null);
+            },
+            ct: CancellationToken.None);
+
+        Assert.Equal("hit", result);
+        Assert.Equal(4, winning);
+        Assert.Equal(1, calls); // exact hit => no extra queries on success
+    }
+
+    [Fact]
+    public async Task TryWithTolerance_MinusOneNearMiss_Resolves()
+    {
+        var calls = 0;
+        var (result, winning) = await CSharpTools.TryWithToleranceAsync<string>(
+            content: "var value = 1;",
+            line: 0,
+            character: 5,
+            probe: (ch, _) =>
+            {
+                calls++;
+                return Task.FromResult<string?>(ch == 4 ? "hit" : null);
+            },
+            ct: CancellationToken.None);
+
+        Assert.Equal("hit", result);
+        Assert.Equal(4, winning); // -1 offset won
+        Assert.Equal(2, calls);   // exact missed (1), -1 hit (2)
+    }
+
+    [Fact]
+    public async Task TryWithTolerance_TrueMiss_ReturnsNullAndRequestedOffset()
+    {
+        var (result, winning) = await CSharpTools.TryWithToleranceAsync<string>(
+            content: "var value = 1;",
+            line: 0,
+            character: 5,
+            probe: (_, _) => Task.FromResult<string?>(null),
+            ct: CancellationToken.None);
+
+        Assert.Null(result);
+        Assert.Equal(5, winning);
+    }
+
+    [Fact]
+    public void BuildToleranceRing_AtLineEnd_NeverCrossesBoundary()
+    {
+        // "var x;" has length 6; request sits at the line end.
+        var ring = CSharpTools.BuildToleranceRing(character: 6, lineLength: 6);
+
+        Assert.Equal(6, ring[0]);          // exact offset probed first
+        Assert.All(ring, o => Assert.InRange(o, 0, 6));
+        Assert.DoesNotContain(7, ring);    // never overshoots to (what would be) the next line
+        Assert.True(ring.Count <= ToleranceDeltaCount);
+    }
+
+    [Fact]
+    public void BuildToleranceRing_AtLineStart_NeverGoesNegative()
+    {
+        var ring = CSharpTools.BuildToleranceRing(character: 0, lineLength: 6);
+
+        Assert.Equal(0, ring[0]);
+        Assert.All(ring, o => Assert.InRange(o, 0, 6));
+        Assert.DoesNotContain(-1, ring);
+    }
+
+    [Fact]
+    public void BuildToleranceRing_MidLine_YieldsExactMinusOnePlusOneMinusTwo()
+    {
+        var ring = CSharpTools.BuildToleranceRing(character: 10, lineLength: 40);
+
+        Assert.Equal(new[] { 10, 9, 11, 8 }, ring);
+    }
+
+    [Theory]
+    [InlineData("abc\ndefgh\n", 0, 3)]
+    [InlineData("abc\ndefgh\n", 1, 5)]
+    [InlineData("abc\r\ndefgh", 0, 3)]  // CRLF terminator stripped
+    [InlineData("abc\ndefgh\n", 9, 0)]  // line out of range => clamp source is 0
+    public void GetLineLength_ReturnsCharCountExcludingTerminator(string content, int line, int expected)
+    {
+        Assert.Equal(expected, CSharpTools.GetLineLength(content, line));
+    }
+
+    private static int ToleranceDeltaCount => CSharpTools.ToleranceDeltas.Length;
+}

--- a/csharp-lsp-mcp/src/CSharpLspMcp/CSharpLspMcp.csproj
+++ b/csharp-lsp-mcp/src/CSharpLspMcp/CSharpLspMcp.csproj
@@ -46,4 +46,8 @@
     <None Include="..\..\..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="CSharpLspMcp.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/csharp-lsp-mcp/src/CSharpLspMcp/Tools/CSharpTools.cs
+++ b/csharp-lsp-mcp/src/CSharpLspMcp/Tools/CSharpTools.cs
@@ -160,10 +160,16 @@ public class CSharpTools
             var absolutePath = GetAbsolutePath(filePath);
             await EnsureDocumentOpenAsync(absolutePath, content, ct);
 
-            var hover = await _lspClient.GetHoverAsync(absolutePath, line, character, ct);
-            if (hover == null)
-                return "No hover information available at this position.";
+            var docContent = GetOpenDocumentContent(absolutePath, content);
+            var (hover, winningOffset) = await TryWithToleranceAsync(
+                docContent, line, character,
+                (ch, c) => _lspClient.GetHoverAsync(absolutePath, line, ch, c),
+                ct);
 
+            if (hover == null)
+                return BuildPositionMissMessage("hover information", line, character);
+
+            LogToleranceWin("csharp_hover", character, line, winningOffset);
             return FormatHoverContent(hover.Contents);
         }, cancellationToken);
     }
@@ -219,9 +225,20 @@ public class CSharpTools
             var absolutePath = GetAbsolutePath(filePath);
             await EnsureDocumentOpenAsync(absolutePath, content, ct);
 
-            var locations = await _lspClient.GetDefinitionAsync(absolutePath, line, character, ct);
+            var docContent = GetOpenDocumentContent(absolutePath, content);
+            var (locations, winningOffset) = await TryWithToleranceAsync(
+                docContent, line, character,
+                async (ch, c) =>
+                {
+                    var locs = await _lspClient.GetDefinitionAsync(absolutePath, line, ch, c);
+                    return locs is { Length: > 0 } ? locs : null;
+                },
+                ct);
+
             if (locations == null || locations.Length == 0)
-                return "No definition found.";
+                return BuildPositionMissMessage("definition", line, character);
+
+            LogToleranceWin("csharp_definition", character, line, winningOffset);
 
             var sb = new StringBuilder();
             sb.AppendLine($"Found {locations.Length} definition(s):\n");
@@ -398,6 +415,115 @@ public class CSharpTools
     {
         _workspacePath = path;
     }
+
+    // Same-line position-tolerance ring (kb-4110). AI agents lack a precise editor caret and
+    // routinely miss the target symbol by a character or two, turning a near-miss into a hard
+    // "nothing here" error. On the miss path only, retry a tiny ring of nearby offsets on the
+    // SAME line so tolerance never silently resolves a symbol on an adjacent line. csharp-lsp
+    // positions are 0-based (no 1->0 conversion); the ring operates directly on the character offset.
+    internal static readonly int[] ToleranceDeltas = { 0, -1, 1, -2 };
+
+    /// <summary>
+    /// Number of characters on the given 0-based <paramref name="line"/> of <paramref name="content"/>,
+    /// excluding the line terminator (CRLF-safe). Returns 0 when the content is empty or the line is
+    /// out of range — callers clamp the ring to <c>[0, lineLength]</c> so an out-of-range line yields
+    /// only offset 0.
+    /// </summary>
+    internal static int GetLineLength(string? content, int line)
+    {
+        if (string.IsNullOrEmpty(content) || line < 0)
+            return 0;
+
+        var start = 0;
+        var currentLine = 0;
+        while (currentLine < line)
+        {
+            var nl = content.IndexOf('\n', start);
+            if (nl < 0)
+                return 0; // requested line is past the end of the document
+            start = nl + 1;
+            currentLine++;
+        }
+
+        var end = content.IndexOf('\n', start);
+        if (end < 0)
+            end = content.Length;
+
+        var length = end - start;
+        if (length > 0 && content[start + length - 1] == '\r')
+            length--; // strip the CR of a CRLF terminator
+
+        return length;
+    }
+
+    /// <summary>
+    /// Builds the ordered, deduplicated tolerance ring of character offsets to probe for a
+    /// requested <paramref name="character"/>, each hard-clamped to <c>[0, lineLength]</c> so the
+    /// ring can never cross to an adjacent line. The first element is always the (clamped) exact
+    /// offset, so an exact hit performs exactly one probe.
+    /// </summary>
+    internal static IReadOnlyList<int> BuildToleranceRing(int character, int lineLength)
+    {
+        var ring = new List<int>(ToleranceDeltas.Length);
+        foreach (var delta in ToleranceDeltas)
+        {
+            var candidate = character + delta;
+            if (candidate < 0)
+                candidate = 0;
+            else if (candidate > lineLength)
+                candidate = lineLength;
+
+            if (!ring.Contains(candidate))
+                ring.Add(candidate);
+        }
+
+        return ring;
+    }
+
+    /// <summary>
+    /// Invokes <paramref name="probe"/> across the same-line tolerance ring for the requested
+    /// position, returning the first non-null result and the winning character offset. Stops at
+    /// the first hit, so a successful exact lookup issues no extra queries. On a full miss returns
+    /// <c>(null, character)</c>. The <paramref name="probe"/> is expected to normalize an empty
+    /// result to <c>null</c>.
+    /// </summary>
+    internal static async Task<(T? Result, int WinningOffset)> TryWithToleranceAsync<T>(
+        string? content,
+        int line,
+        int character,
+        Func<int, CancellationToken, Task<T?>> probe,
+        CancellationToken ct) where T : class
+    {
+        var lineLength = GetLineLength(content, line);
+        var ring = BuildToleranceRing(character, lineLength);
+
+        foreach (var offset in ring)
+        {
+            var result = await probe(offset, ct);
+            if (result != null)
+                return (result, offset);
+        }
+
+        return (null, character);
+    }
+
+    private string? GetOpenDocumentContent(string filePath, string? fallback)
+        => _openDocuments.TryGetValue(filePath, out var state) ? state.Content : fallback;
+
+    private void LogToleranceWin(string tool, int requested, int line, int winningOffset)
+    {
+        if (winningOffset != requested)
+        {
+            _logger.LogInformation(
+                "{Tool} resolved via same-line tolerance: requested character {Requested}, winning character {Winning} (line {Line})",
+                tool, requested, winningOffset, line);
+        }
+    }
+
+    private static string BuildPositionMissMessage(string what, int line, int character)
+        => $"No {what} found at line {line}, character {character} after same-line tolerance retry. " +
+           "Positions are 0-based — point `character` at the first letter of the target symbol's name " +
+           "(not whitespace, punctuation, or the end of the token), and confirm `line` is 0-based.";
 
     private async Task EnsureDocumentOpenAsync(string filePath, string? content, CancellationToken ct)
     {

--- a/csharp-lsp-mcp/src/CSharpLspMcp/Tools/CSharpTools.cs
+++ b/csharp-lsp-mcp/src/CSharpLspMcp/Tools/CSharpTools.cs
@@ -15,6 +15,7 @@ public class CSharpTools
 {
     private readonly ILogger<CSharpTools> _logger;
     private readonly LspClient _lspClient;
+    private readonly ToleranceTelemetrySink _toleranceSink;
     private readonly Dictionary<string, DocumentState> _openDocuments = new();
     private string? _workspacePath;
 
@@ -26,6 +27,8 @@ public class CSharpTools
     {
         _logger = logger;
         _lspClient = lspClient;
+        // Opt-in JSONL telemetry; a no-op unless CSHARP_LSP_TOLERANCE_LOG is set (see ToleranceTelemetrySink).
+        _toleranceSink = ToleranceTelemetrySink.FromEnvironment();
     }
 
     /// <summary>
@@ -167,9 +170,12 @@ public class CSharpTools
                 ct);
 
             if (hover == null)
+            {
+                RecordToleranceOutcome("csharp_hover", line, character, winning: null);
                 return BuildPositionMissMessage("hover information", line, character);
+            }
 
-            LogToleranceWin("csharp_hover", character, line, winningOffset);
+            RecordToleranceOutcome("csharp_hover", line, character, winningOffset);
             return FormatHoverContent(hover.Contents);
         }, cancellationToken);
     }
@@ -189,9 +195,23 @@ public class CSharpTools
             var absolutePath = GetAbsolutePath(filePath);
             await EnsureDocumentOpenAsync(absolutePath, content, ct);
 
-            var completions = await _lspClient.GetCompletionsAsync(absolutePath, line, character, ct);
+            var docContent = GetOpenDocumentContent(absolutePath, content);
+            var (completions, winningOffset) = await TryWithToleranceAsync(
+                docContent, line, character,
+                async (ch, c) =>
+                {
+                    var items = await _lspClient.GetCompletionsAsync(absolutePath, line, ch, c);
+                    return items is { Length: > 0 } ? items : null;
+                },
+                ct);
+
             if (completions == null || completions.Length == 0)
-                return "No completions available.";
+            {
+                RecordToleranceOutcome("csharp_completions", line, character, winning: null);
+                return BuildPositionMissMessage("completions", line, character);
+            }
+
+            RecordToleranceOutcome("csharp_completions", line, character, winningOffset);
 
             var sb = new StringBuilder();
             sb.AppendLine($"Found {completions.Length} completion(s):\n");
@@ -236,9 +256,12 @@ public class CSharpTools
                 ct);
 
             if (locations == null || locations.Length == 0)
+            {
+                RecordToleranceOutcome("csharp_definition", line, character, winning: null);
                 return BuildPositionMissMessage("definition", line, character);
+            }
 
-            LogToleranceWin("csharp_definition", character, line, winningOffset);
+            RecordToleranceOutcome("csharp_definition", line, character, winningOffset);
 
             var sb = new StringBuilder();
             sb.AppendLine($"Found {locations.Length} definition(s):\n");
@@ -269,9 +292,23 @@ public class CSharpTools
             var absolutePath = GetAbsolutePath(filePath);
             await EnsureDocumentOpenAsync(absolutePath, content, ct);
 
-            var locations = await _lspClient.GetReferencesAsync(absolutePath, line, character, includeDeclaration, ct);
+            var docContent = GetOpenDocumentContent(absolutePath, content);
+            var (locations, winningOffset) = await TryWithToleranceAsync(
+                docContent, line, character,
+                async (ch, c) =>
+                {
+                    var locs = await _lspClient.GetReferencesAsync(absolutePath, line, ch, includeDeclaration, c);
+                    return locs is { Length: > 0 } ? locs : null;
+                },
+                ct);
+
             if (locations == null || locations.Length == 0)
-                return "No references found.";
+            {
+                RecordToleranceOutcome("csharp_references", line, character, winning: null);
+                return BuildPositionMissMessage("references", line, character);
+            }
+
+            RecordToleranceOutcome("csharp_references", line, character, winningOffset);
 
             var sb = new StringBuilder();
             sb.AppendLine($"Found {locations.Length} reference(s):\n");
@@ -510,14 +547,20 @@ public class CSharpTools
     private string? GetOpenDocumentContent(string filePath, string? fallback)
         => _openDocuments.TryGetValue(filePath, out var state) ? state.Content : fallback;
 
-    private void LogToleranceWin(string tool, int requested, int line, int winningOffset)
+    // Surfaces a tolerance outcome two ways: a human-readable ILogger line when the ring actually
+    // recovered the lookup (winning offset differs from the request), and a structured JSONL record
+    // for every outcome (exact / tolerance / miss) when the opt-in telemetry sink is enabled.
+    // A miss is signalled with winning == null.
+    private void RecordToleranceOutcome(string tool, int line, int requested, int? winning)
     {
-        if (winningOffset != requested)
+        if (winning is int w && w != requested)
         {
             _logger.LogInformation(
                 "{Tool} resolved via same-line tolerance: requested character {Requested}, winning character {Winning} (line {Line})",
-                tool, requested, winningOffset, line);
+                tool, requested, w, line);
         }
+
+        _toleranceSink.Record(tool, line, requested, winning);
     }
 
     private static string BuildPositionMissMessage(string what, int line, int character)

--- a/csharp-lsp-mcp/src/CSharpLspMcp/Tools/ToleranceTelemetrySink.cs
+++ b/csharp-lsp-mcp/src/CSharpLspMcp/Tools/ToleranceTelemetrySink.cs
@@ -1,0 +1,159 @@
+using System.Text.Json;
+
+namespace CSharpLspMcp.Tools;
+
+/// <summary>
+/// Opt-in, lock-safe JSONL sink that records same-line position-tolerance outcomes so the
+/// <c>{0, -1, +1, -2}</c> ring can be validated against the real distribution of winning offsets
+/// seen in production. It is activated only when the <see cref="PathEnvVar"/> environment variable
+/// points at a writable file path; when unset, every call is a cheap no-op (a single null check),
+/// so default behavior and the happy path are completely unchanged.
+/// </summary>
+/// <remarks>
+/// One JSON object is appended per line (JSON Lines / NDJSON):
+/// <code>
+/// {"ts":"2026-06-24T16:00:00.000Z","tool":"csharp_definition","line":12,"requested":8,"winning":7,"delta":-1,"outcome":"tolerance"}
+/// </code>
+/// <para>
+/// Downstream tooling builds a histogram by grouping on <c>delta</c> (or <c>outcome</c>): the count
+/// of <c>exact</c> vs <c>tolerance</c> (and which delta won) vs <c>miss</c> answers whether the ring
+/// is well chosen and whether any offset is dead weight.
+/// </para>
+/// <para>
+/// Writes are lock-safe both in-process (a private monitor) and across processes (append-mode
+/// <see cref="FileStream"/> opened with <see cref="FileShare.ReadWrite"/> plus a short bounded retry
+/// on sharing/IO contention). Each record is written as a single line so concurrent appends never
+/// interleave into a torn JSON object.
+/// </para>
+/// </remarks>
+internal sealed class ToleranceTelemetrySink
+{
+    /// <summary>Environment variable holding the JSONL output path. Unset =&gt; sink disabled.</summary>
+    public const string PathEnvVar = "CSHARP_LSP_TOLERANCE_LOG";
+
+    private const int MaxAppendAttempts = 5;
+
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        // Compact, one object per line — never indent (would break the line-per-record contract).
+        WriteIndented = false,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+
+    private readonly object _gate = new();
+    private readonly string? _path;
+
+    /// <summary>
+    /// Creates a sink writing to <paramref name="path"/>. A null/whitespace path produces a disabled
+    /// (no-op) sink. The target directory is created eagerly so the first <see cref="Record"/> never
+    /// fails on a missing folder.
+    /// </summary>
+    public ToleranceTelemetrySink(string? path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            _path = null;
+            return;
+        }
+
+        _path = path;
+
+        try
+        {
+            var dir = Path.GetDirectoryName(Path.GetFullPath(path));
+            if (!string.IsNullOrEmpty(dir))
+                Directory.CreateDirectory(dir);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or NotSupportedException)
+        {
+            // Telemetry is best-effort: a bad path must never disable the tool. Disable the sink instead.
+            _path = null;
+        }
+    }
+
+    /// <summary>Builds a sink from <see cref="PathEnvVar"/>. Returns a disabled sink when unset.</summary>
+    public static ToleranceTelemetrySink FromEnvironment()
+        => new(Environment.GetEnvironmentVariable(PathEnvVar));
+
+    /// <summary>True when a valid output path is configured and records will be written.</summary>
+    public bool IsEnabled => _path is not null;
+
+    /// <summary>
+    /// Records one tolerance outcome. <paramref name="winning"/> is the winning character offset, or
+    /// <c>null</c> when the lookup missed entirely after the full ring was probed. No-op when disabled.
+    /// Best-effort: any IO failure is swallowed so telemetry never breaks a tool call.
+    /// </summary>
+    public void Record(string tool, int line, int requested, int? winning)
+    {
+        if (_path is null)
+            return;
+
+        try
+        {
+            Append(BuildRecord(tool, line, requested, winning, DateTimeOffset.UtcNow));
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            // Swallow — see remarks. The ILogger path already surfaced the win.
+        }
+    }
+
+    /// <summary>
+    /// Serializes a single JSONL record. <c>outcome</c> is <c>"miss"</c> when <paramref name="winning"/>
+    /// is null, <c>"exact"</c> when it equals <paramref name="requested"/>, otherwise <c>"tolerance"</c>;
+    /// <c>delta</c> is <c>winning - requested</c> (null on a miss). Exposed for unit tests.
+    /// </summary>
+    internal static string BuildRecord(string tool, int line, int requested, int? winning, DateTimeOffset timestamp)
+    {
+        var outcome = winning switch
+        {
+            null => "miss",
+            var w when w == requested => "exact",
+            _ => "tolerance"
+        };
+
+        var record = new ToleranceRecord(
+            Ts: timestamp.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss.fffZ"),
+            Tool: tool,
+            Line: line,
+            Requested: requested,
+            Winning: winning,
+            Delta: winning is int w2 ? w2 - requested : null,
+            Outcome: outcome);
+
+        return JsonSerializer.Serialize(record, SerializerOptions);
+    }
+
+    private void Append(string jsonLine)
+    {
+        lock (_gate)
+        {
+            for (var attempt = 1; ; attempt++)
+            {
+                try
+                {
+                    using var stream = new FileStream(
+                        _path!, FileMode.Append, FileAccess.Write, FileShare.ReadWrite);
+                    using var writer = new StreamWriter(stream);
+                    writer.WriteLine(jsonLine);
+                    writer.Flush();
+                    return;
+                }
+                catch (IOException) when (attempt < MaxAppendAttempts)
+                {
+                    // Another process/thread holds the handle; back off briefly and retry.
+                    Thread.Sleep(10 * attempt);
+                }
+            }
+        }
+    }
+
+    private sealed record ToleranceRecord(
+        string Ts,
+        string Tool,
+        int Line,
+        int Requested,
+        int? Winning,
+        int? Delta,
+        string Outcome);
+}


### PR DESCRIPTION
## Summary

Position-based C# tools (`csharp_definition`, `csharp_hover`, and — once the follow-up commit lands — `csharp_references` / `csharp_completions`) currently return a hard *"No definition found." / "No hover information available."* when the requested `(line, character)` is off by a character or two. This is a frequent failure mode for **AI / MCP callers**, which compute positions from text rather than a real editor caret and routinely land on whitespace, punctuation, or one past the end of a token.

This PR adds a small, **same-line position-tolerance ring** on the **miss path only**:

- Probe order is `exact, -1, +1, -2` (0-based character offsets), each **hard-clamped to `[0, lineLength]`** so a retry can **never cross onto an adjacent line** (no silently resolving the wrong symbol).
- An **exact hit issues exactly one probe** — zero behavioral or performance change on the happy path.
- The winning offset is logged via `ILogger` when tolerance recovered the lookup, so the behavior is observable.
- A true miss now returns a **recovery-oriented, 0-based** message telling the caller to point `character` at the first letter of the symbol name.

### Why a ring instead of widening the search

LSP `textDocument/definition` etc. are already position-precise; the problem is purely *caller aim*. A bounded, same-line ring fixes off-by-one aim without changing semantics for correct callers and without ever jumping lines.

## Design notes

- `TryWithToleranceAsync<T>` — generic miss-path retry; stops at first non-null result; returns `(result, winningOffset)`.
- `BuildToleranceRing(character, lineLength)` — ordered, de-duplicated, clamped offsets; exact offset always first.
- `GetLineLength(content, line)` — CRLF-safe line length used to clamp the ring; out-of-range line clamps the ring to offset `0`.
- All three helpers are `internal` + covered by unit tests via `InternalsVisibleTo`.

## Tests

`ToleranceTests.cs` covers: exact hit issues no extra probes, `-1` near-miss resolves, true miss returns `(null, requested)`, ring never crosses the line boundary at start/end, mid-line ordering, and `GetLineLength` (LF, CRLF, out-of-range).

## Notes for maintainers

- Base branch is `master`.
- The first commit carries internal ticket references in its footer from my downstream fork; **feel free to squash-merge** with a clean message — the change itself is self-contained and dependency-free.
- A follow-up commit on this branch extends the same ring to `csharp_references` / `csharp_completions` and adds an **opt-in, lock-safe JSONL telemetry sink** (activated only when an env var points at a log path; otherwise a no-op) so the `{0,-1,+1,-2}` ring can be validated against real winning-offset distributions. CHANGELOG and README are updated there.
